### PR TITLE
Remove Mac X64 benchmark from GitHub Actions workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,9 +47,6 @@ jobs:
         with:
           gradle-version: wrapper
 
-      - name: Run Native Mac X64 benchmark
-        run: ./gradlew :jsonpath-benchmarks:runReleaseExecutableMacosX64
-
       - name: Run Native Mac ARM64 benchmark
         run: ./gradlew :jsonpath-benchmarks:runReleaseExecutableMacosArm64
 


### PR DESCRIPTION
Removed the Mac X64 benchmark run step from the workflow.