### PR TITLE
Add Kotlin binary compatibility validation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,6 +58,24 @@ jobs:
       - name: Run ktlint
         run: ./format --no-format
 
+  abi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version-file: .ci-java-version
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+
+      - name: Check binary compatibility
+        run: ./gradlew checkKotlinAbi
+
   test:
     strategy:
       matrix:

--- a/jsonpath-core/api/jsonpath-core.api
+++ b/jsonpath-core/api/jsonpath-core.api
@@ -1,0 +1,110 @@
+public final class com/nfeld/jsonpathkt/JsonPath {
+	public static final field Companion Lcom/nfeld/jsonpathkt/JsonPath$Companion;
+	public static final synthetic fun box-impl (Ljava/util/List;)Lcom/nfeld/jsonpathkt/JsonPath;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/util/List;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/util/List;Ljava/util/List;)Z
+	public static final fun getTokenCount-impl (Ljava/util/List;)I
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/util/List;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/util/List;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/util/List;
+}
+
+public final class com/nfeld/jsonpathkt/JsonPath$Companion {
+	public final fun compile-8MMqd_U (Ljava/lang/String;)Ljava/util/List;
+}
+
+public final class com/nfeld/jsonpathkt/ResolutionOptions {
+	public static final field Companion Lcom/nfeld/jsonpathkt/ResolutionOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/nfeld/jsonpathkt/ResolutionOptions;
+	public static synthetic fun copy$default (Lcom/nfeld/jsonpathkt/ResolutionOptions;ZILjava/lang/Object;)Lcom/nfeld/jsonpathkt/ResolutionOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getWrapSingleValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/nfeld/jsonpathkt/ResolutionOptions$Companion {
+	public final fun getDefault ()Lcom/nfeld/jsonpathkt/ResolutionOptions;
+}
+
+public abstract class com/nfeld/jsonpathkt/json/JsonNode {
+	public fun <init> (Ljava/lang/Object;Z)V
+	public abstract fun copy (Ljava/lang/Object;Z)Lcom/nfeld/jsonpathkt/json/JsonNode;
+	public static synthetic fun copy$default (Lcom/nfeld/jsonpathkt/json/JsonNode;Ljava/lang/Object;ZILjava/lang/Object;)Lcom/nfeld/jsonpathkt/json/JsonNode;
+	public abstract fun createJsonLiteral (Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun getAsArray ()Ljava/util/List;
+	public abstract fun getAsObject ()Ljava/util/Map;
+	public abstract fun getAsObjectValues ()Ljava/util/Collection;
+	public abstract fun getAsString ()Ljava/lang/String;
+	public final fun getElement ()Ljava/lang/Object;
+	public abstract fun getEmptyJsonArray ()Ljava/lang/Object;
+	public abstract fun getType ()Lcom/nfeld/jsonpathkt/json/JsonType;
+	public abstract fun isNotNull ()Z
+	public abstract fun isNull (Ljava/lang/Object;)Z
+	public abstract fun toJsonArray (Ljava/util/List;)Ljava/lang/Object;
+}
+
+public final class com/nfeld/jsonpathkt/json/JsonType : java/lang/Enum {
+	public static final field Array Lcom/nfeld/jsonpathkt/json/JsonType;
+	public static final field Null Lcom/nfeld/jsonpathkt/json/JsonType;
+	public static final field Object Lcom/nfeld/jsonpathkt/json/JsonType;
+	public static final field Primitive Lcom/nfeld/jsonpathkt/json/JsonType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun isArrayOrObject ()Z
+	public static fun valueOf (Ljava/lang/String;)Lcom/nfeld/jsonpathkt/json/JsonType;
+	public static fun values ()[Lcom/nfeld/jsonpathkt/json/JsonType;
+}
+
+public final class com/nfeld/jsonpathkt/tokens/ArrayAccessorToken : com/nfeld/jsonpathkt/tokens/Token {
+	public static final field Companion Lcom/nfeld/jsonpathkt/tokens/ArrayAccessorToken$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lcom/nfeld/jsonpathkt/tokens/ArrayAccessorToken;
+	public static synthetic fun copy$default (Lcom/nfeld/jsonpathkt/tokens/ArrayAccessorToken;IILjava/lang/Object;)Lcom/nfeld/jsonpathkt/tokens/ArrayAccessorToken;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()I
+	public fun hashCode ()I
+	public fun read (Lcom/nfeld/jsonpathkt/json/JsonNode;)Lcom/nfeld/jsonpathkt/json/JsonNode;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/nfeld/jsonpathkt/tokens/ArrayAccessorToken$Companion {
+	public final fun read (Lcom/nfeld/jsonpathkt/json/JsonNode;I)Lcom/nfeld/jsonpathkt/json/JsonNode;
+}
+
+public final class com/nfeld/jsonpathkt/tokens/ObjectAccessorToken : com/nfeld/jsonpathkt/tokens/Token {
+	public static final field Companion Lcom/nfeld/jsonpathkt/tokens/ObjectAccessorToken$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/nfeld/jsonpathkt/tokens/ObjectAccessorToken;
+	public static synthetic fun copy$default (Lcom/nfeld/jsonpathkt/tokens/ObjectAccessorToken;Ljava/lang/String;ILjava/lang/Object;)Lcom/nfeld/jsonpathkt/tokens/ObjectAccessorToken;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun read (Lcom/nfeld/jsonpathkt/json/JsonNode;)Lcom/nfeld/jsonpathkt/json/JsonNode;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/nfeld/jsonpathkt/tokens/ObjectAccessorToken$Companion {
+	public final fun read (Lcom/nfeld/jsonpathkt/json/JsonNode;Ljava/lang/String;)Lcom/nfeld/jsonpathkt/json/JsonNode;
+}
+
+public abstract interface class com/nfeld/jsonpathkt/tokens/Token {
+	public abstract fun read (Lcom/nfeld/jsonpathkt/json/JsonNode;)Lcom/nfeld/jsonpathkt/json/JsonNode;
+}
+
+public final class com/nfeld/jsonpathkt/tokens/WildcardToken : com/nfeld/jsonpathkt/tokens/Token {
+	public static final field INSTANCE Lcom/nfeld/jsonpathkt/tokens/WildcardToken;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun read (Lcom/nfeld/jsonpathkt/json/JsonNode;)Lcom/nfeld/jsonpathkt/json/JsonNode;
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/jsonpath-core/api/jsonpath-core.klib.api
+++ b/jsonpath-core/api/jsonpath-core.klib.api
@@ -1,0 +1,131 @@
+// Klib ABI Dump
+// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <com.eygraber:jsonpath-core>
+final enum class com.nfeld.jsonpathkt.json/JsonType : kotlin/Enum<com.nfeld.jsonpathkt.json/JsonType> { // com.nfeld.jsonpathkt.json/JsonType|null[0]
+    enum entry Array // com.nfeld.jsonpathkt.json/JsonType.Array|null[0]
+    enum entry Null // com.nfeld.jsonpathkt.json/JsonType.Null|null[0]
+    enum entry Object // com.nfeld.jsonpathkt.json/JsonType.Object|null[0]
+    enum entry Primitive // com.nfeld.jsonpathkt.json/JsonType.Primitive|null[0]
+
+    final val entries // com.nfeld.jsonpathkt.json/JsonType.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.nfeld.jsonpathkt.json/JsonType> // com.nfeld.jsonpathkt.json/JsonType.entries.<get-entries>|<get-entries>#static(){}[0]
+    final val isArrayOrObject // com.nfeld.jsonpathkt.json/JsonType.isArrayOrObject|{}isArrayOrObject[0]
+        final inline fun <get-isArrayOrObject>(): kotlin/Boolean // com.nfeld.jsonpathkt.json/JsonType.isArrayOrObject.<get-isArrayOrObject>|<get-isArrayOrObject>(){}[0]
+
+    final fun valueOf(kotlin/String): com.nfeld.jsonpathkt.json/JsonType // com.nfeld.jsonpathkt.json/JsonType.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.nfeld.jsonpathkt.json/JsonType> // com.nfeld.jsonpathkt.json/JsonType.values|values#static(){}[0]
+}
+
+abstract interface com.nfeld.jsonpathkt.tokens/Token { // com.nfeld.jsonpathkt.tokens/Token|null[0]
+    abstract fun read(com.nfeld.jsonpathkt.json/JsonNode): com.nfeld.jsonpathkt.json/JsonNode? // com.nfeld.jsonpathkt.tokens/Token.read|read(com.nfeld.jsonpathkt.json.JsonNode){}[0]
+}
+
+abstract class com.nfeld.jsonpathkt.json/JsonNode { // com.nfeld.jsonpathkt.json/JsonNode|null[0]
+    constructor <init>(kotlin/Any, kotlin/Boolean) // com.nfeld.jsonpathkt.json/JsonNode.<init>|<init>(kotlin.Any;kotlin.Boolean){}[0]
+
+    abstract val asArray // com.nfeld.jsonpathkt.json/JsonNode.asArray|{}asArray[0]
+        abstract fun <get-asArray>(): kotlin.collections/List<kotlin/Any> // com.nfeld.jsonpathkt.json/JsonNode.asArray.<get-asArray>|<get-asArray>(){}[0]
+    abstract val asObject // com.nfeld.jsonpathkt.json/JsonNode.asObject|{}asObject[0]
+        abstract fun <get-asObject>(): kotlin.collections/Map<kotlin/String, kotlin/Any> // com.nfeld.jsonpathkt.json/JsonNode.asObject.<get-asObject>|<get-asObject>(){}[0]
+    abstract val asObjectValues // com.nfeld.jsonpathkt.json/JsonNode.asObjectValues|{}asObjectValues[0]
+        abstract fun <get-asObjectValues>(): kotlin.collections/Collection<kotlin/Any> // com.nfeld.jsonpathkt.json/JsonNode.asObjectValues.<get-asObjectValues>|<get-asObjectValues>(){}[0]
+    abstract val asString // com.nfeld.jsonpathkt.json/JsonNode.asString|{}asString[0]
+        abstract fun <get-asString>(): kotlin/String? // com.nfeld.jsonpathkt.json/JsonNode.asString.<get-asString>|<get-asString>(){}[0]
+    abstract val emptyJsonArray // com.nfeld.jsonpathkt.json/JsonNode.emptyJsonArray|{}emptyJsonArray[0]
+        abstract fun <get-emptyJsonArray>(): kotlin/Any // com.nfeld.jsonpathkt.json/JsonNode.emptyJsonArray.<get-emptyJsonArray>|<get-emptyJsonArray>(){}[0]
+    abstract val isNotNull // com.nfeld.jsonpathkt.json/JsonNode.isNotNull|{}isNotNull[0]
+        abstract fun <get-isNotNull>(): kotlin/Boolean // com.nfeld.jsonpathkt.json/JsonNode.isNotNull.<get-isNotNull>|<get-isNotNull>(){}[0]
+    abstract val isNull // com.nfeld.jsonpathkt.json/JsonNode.isNull|@kotlin.Any?{}isNull[0]
+        abstract fun (kotlin/Any?).<get-isNull>(): kotlin/Boolean // com.nfeld.jsonpathkt.json/JsonNode.isNull.<get-isNull>|<get-isNull>@kotlin.Any?(){}[0]
+    abstract val type // com.nfeld.jsonpathkt.json/JsonNode.type|{}type[0]
+        abstract fun <get-type>(): com.nfeld.jsonpathkt.json/JsonType // com.nfeld.jsonpathkt.json/JsonNode.type.<get-type>|<get-type>(){}[0]
+    final val element // com.nfeld.jsonpathkt.json/JsonNode.element|{}element[0]
+        final fun <get-element>(): kotlin/Any // com.nfeld.jsonpathkt.json/JsonNode.element.<get-element>|<get-element>(){}[0]
+
+    abstract fun copy(kotlin/Any = ..., kotlin/Boolean = ...): com.nfeld.jsonpathkt.json/JsonNode // com.nfeld.jsonpathkt.json/JsonNode.copy|copy(kotlin.Any;kotlin.Boolean){}[0]
+    abstract fun createJsonLiteral(kotlin/String): kotlin/Any // com.nfeld.jsonpathkt.json/JsonNode.createJsonLiteral|createJsonLiteral(kotlin.String){}[0]
+    abstract fun toJsonArray(kotlin.collections/List<kotlin/Any>): kotlin/Any // com.nfeld.jsonpathkt.json/JsonNode.toJsonArray|toJsonArray(kotlin.collections.List<kotlin.Any>){}[0]
+}
+
+final class com.nfeld.jsonpathkt.tokens/ArrayAccessorToken : com.nfeld.jsonpathkt.tokens/Token { // com.nfeld.jsonpathkt.tokens/ArrayAccessorToken|null[0]
+    constructor <init>(kotlin/Int) // com.nfeld.jsonpathkt.tokens/ArrayAccessorToken.<init>|<init>(kotlin.Int){}[0]
+
+    final val index // com.nfeld.jsonpathkt.tokens/ArrayAccessorToken.index|{}index[0]
+        final fun <get-index>(): kotlin/Int // com.nfeld.jsonpathkt.tokens/ArrayAccessorToken.index.<get-index>|<get-index>(){}[0]
+
+    final fun component1(): kotlin/Int // com.nfeld.jsonpathkt.tokens/ArrayAccessorToken.component1|component1(){}[0]
+    final fun copy(kotlin/Int = ...): com.nfeld.jsonpathkt.tokens/ArrayAccessorToken // com.nfeld.jsonpathkt.tokens/ArrayAccessorToken.copy|copy(kotlin.Int){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.nfeld.jsonpathkt.tokens/ArrayAccessorToken.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.nfeld.jsonpathkt.tokens/ArrayAccessorToken.hashCode|hashCode(){}[0]
+    final fun read(com.nfeld.jsonpathkt.json/JsonNode): com.nfeld.jsonpathkt.json/JsonNode? // com.nfeld.jsonpathkt.tokens/ArrayAccessorToken.read|read(com.nfeld.jsonpathkt.json.JsonNode){}[0]
+    final fun toString(): kotlin/String // com.nfeld.jsonpathkt.tokens/ArrayAccessorToken.toString|toString(){}[0]
+
+    final object Companion { // com.nfeld.jsonpathkt.tokens/ArrayAccessorToken.Companion|null[0]
+        final fun read(com.nfeld.jsonpathkt.json/JsonNode, kotlin/Int): com.nfeld.jsonpathkt.json/JsonNode? // com.nfeld.jsonpathkt.tokens/ArrayAccessorToken.Companion.read|read(com.nfeld.jsonpathkt.json.JsonNode;kotlin.Int){}[0]
+    }
+}
+
+final class com.nfeld.jsonpathkt.tokens/ObjectAccessorToken : com.nfeld.jsonpathkt.tokens/Token { // com.nfeld.jsonpathkt.tokens/ObjectAccessorToken|null[0]
+    constructor <init>(kotlin/String) // com.nfeld.jsonpathkt.tokens/ObjectAccessorToken.<init>|<init>(kotlin.String){}[0]
+
+    final val key // com.nfeld.jsonpathkt.tokens/ObjectAccessorToken.key|{}key[0]
+        final fun <get-key>(): kotlin/String // com.nfeld.jsonpathkt.tokens/ObjectAccessorToken.key.<get-key>|<get-key>(){}[0]
+
+    final fun component1(): kotlin/String // com.nfeld.jsonpathkt.tokens/ObjectAccessorToken.component1|component1(){}[0]
+    final fun copy(kotlin/String = ...): com.nfeld.jsonpathkt.tokens/ObjectAccessorToken // com.nfeld.jsonpathkt.tokens/ObjectAccessorToken.copy|copy(kotlin.String){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.nfeld.jsonpathkt.tokens/ObjectAccessorToken.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.nfeld.jsonpathkt.tokens/ObjectAccessorToken.hashCode|hashCode(){}[0]
+    final fun read(com.nfeld.jsonpathkt.json/JsonNode): com.nfeld.jsonpathkt.json/JsonNode? // com.nfeld.jsonpathkt.tokens/ObjectAccessorToken.read|read(com.nfeld.jsonpathkt.json.JsonNode){}[0]
+    final fun toString(): kotlin/String // com.nfeld.jsonpathkt.tokens/ObjectAccessorToken.toString|toString(){}[0]
+
+    final object Companion { // com.nfeld.jsonpathkt.tokens/ObjectAccessorToken.Companion|null[0]
+        final fun read(com.nfeld.jsonpathkt.json/JsonNode, kotlin/String): com.nfeld.jsonpathkt.json/JsonNode? // com.nfeld.jsonpathkt.tokens/ObjectAccessorToken.Companion.read|read(com.nfeld.jsonpathkt.json.JsonNode;kotlin.String){}[0]
+    }
+}
+
+final class com.nfeld.jsonpathkt/ResolutionOptions { // com.nfeld.jsonpathkt/ResolutionOptions|null[0]
+    constructor <init>(kotlin/Boolean = ...) // com.nfeld.jsonpathkt/ResolutionOptions.<init>|<init>(kotlin.Boolean){}[0]
+
+    final val wrapSingleValue // com.nfeld.jsonpathkt/ResolutionOptions.wrapSingleValue|{}wrapSingleValue[0]
+        final fun <get-wrapSingleValue>(): kotlin/Boolean // com.nfeld.jsonpathkt/ResolutionOptions.wrapSingleValue.<get-wrapSingleValue>|<get-wrapSingleValue>(){}[0]
+
+    final fun component1(): kotlin/Boolean // com.nfeld.jsonpathkt/ResolutionOptions.component1|component1(){}[0]
+    final fun copy(kotlin/Boolean = ...): com.nfeld.jsonpathkt/ResolutionOptions // com.nfeld.jsonpathkt/ResolutionOptions.copy|copy(kotlin.Boolean){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.nfeld.jsonpathkt/ResolutionOptions.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.nfeld.jsonpathkt/ResolutionOptions.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.nfeld.jsonpathkt/ResolutionOptions.toString|toString(){}[0]
+
+    final object Companion { // com.nfeld.jsonpathkt/ResolutionOptions.Companion|null[0]
+        final val Default // com.nfeld.jsonpathkt/ResolutionOptions.Companion.Default|{}Default[0]
+            final fun <get-Default>(): com.nfeld.jsonpathkt/ResolutionOptions // com.nfeld.jsonpathkt/ResolutionOptions.Companion.Default.<get-Default>|<get-Default>(){}[0]
+    }
+}
+
+final value class com.nfeld.jsonpathkt/JsonPath { // com.nfeld.jsonpathkt/JsonPath|null[0]
+    final val tokenCount // com.nfeld.jsonpathkt/JsonPath.tokenCount|{}tokenCount[0]
+        final inline fun <get-tokenCount>(): kotlin/Int // com.nfeld.jsonpathkt/JsonPath.tokenCount.<get-tokenCount>|<get-tokenCount>(){}[0]
+    final val tokens // com.nfeld.jsonpathkt/JsonPath.tokens|{}tokens[0]
+        final fun <get-tokens>(): kotlin.collections/List<com.nfeld.jsonpathkt.tokens/Token> // com.nfeld.jsonpathkt/JsonPath.tokens.<get-tokens>|<get-tokens>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.nfeld.jsonpathkt/JsonPath.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.nfeld.jsonpathkt/JsonPath.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.nfeld.jsonpathkt/JsonPath.toString|toString(){}[0]
+
+    final object Companion { // com.nfeld.jsonpathkt/JsonPath.Companion|null[0]
+        final fun compile(kotlin/String): com.nfeld.jsonpathkt/JsonPath // com.nfeld.jsonpathkt/JsonPath.Companion.compile|compile(kotlin.String){}[0]
+    }
+}
+
+final object com.nfeld.jsonpathkt.tokens/WildcardToken : com.nfeld.jsonpathkt.tokens/Token { // com.nfeld.jsonpathkt.tokens/WildcardToken|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.nfeld.jsonpathkt.tokens/WildcardToken.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.nfeld.jsonpathkt.tokens/WildcardToken.hashCode|hashCode(){}[0]
+    final fun read(com.nfeld.jsonpathkt.json/JsonNode): com.nfeld.jsonpathkt.json/JsonNode // com.nfeld.jsonpathkt.tokens/WildcardToken.read|read(com.nfeld.jsonpathkt.json.JsonNode){}[0]
+    final fun toString(): kotlin/String // com.nfeld.jsonpathkt.tokens/WildcardToken.toString|toString(){}[0]
+}
+
+final inline fun <#A: reified kotlin/Any?> (com.nfeld.jsonpathkt/JsonPath).com.nfeld.jsonpathkt/resolveOrNull(com.nfeld.jsonpathkt.json/JsonNode, com.nfeld.jsonpathkt/ResolutionOptions = ...): #A? // com.nfeld.jsonpathkt/resolveOrNull|resolveOrNull@com.nfeld.jsonpathkt.JsonPath(com.nfeld.jsonpathkt.json.JsonNode;com.nfeld.jsonpathkt.ResolutionOptions){0§<kotlin.Any?>}[0]

--- a/jsonpath-core/build.gradle.kts
+++ b/jsonpath-core/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
   id("com.eygraber.conventions-kotlin-multiplatform")
   id("com.eygraber.conventions-detekt2")
@@ -9,6 +11,12 @@ kotlin {
   defaultKmpTargets(
     project = project,
   )
+
+  @OptIn(ExperimentalAbiValidation::class)
+  abiValidation {
+    enabled.set(true)
+    klib.enabled.set(true)
+  }
 
   sourceSets {
     commonTest.dependencies {

--- a/jsonpath-jsonjava/api/jsonpath-jsonjava.api
+++ b/jsonpath-jsonjava/api/jsonpath-jsonjava.api
@@ -1,0 +1,48 @@
+public final class com/nfeld/jsonpathkt/jsonjava/JSONElement {
+	public static final synthetic fun box-impl (Ljava/lang/Object;)Lcom/nfeld/jsonpathkt/jsonjava/JSONElement;
+	public static fun constructor-impl (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public static final fun getAsArray-impl (Ljava/lang/Object;)Lorg/json/JSONArray;
+	public static final fun getAsArrayOrNull-impl (Ljava/lang/Object;)Lorg/json/JSONArray;
+	public static final fun getAsObject-impl (Ljava/lang/Object;)Lorg/json/JSONObject;
+	public static final fun getAsObjectOrNull-impl (Ljava/lang/Object;)Lorg/json/JSONObject;
+	public static final fun getAsString-impl (Ljava/lang/Object;)Lorg/json/JSONString;
+	public static final fun getAsStringOrNull-impl (Ljava/lang/Object;)Lorg/json/JSONString;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/Object;)I
+	public static final fun isArray-impl (Ljava/lang/Object;)Z
+	public static final fun isObject-impl (Ljava/lang/Object;)Z
+	public static final fun isString-impl (Ljava/lang/Object;)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/Object;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/Object;
+}
+
+public final class com/nfeld/jsonpathkt/jsonjava/JsonJavaJsonNodeKt {
+	public static final fun toJsonNode (Lorg/json/JSONArray;Z)Lcom/nfeld/jsonpathkt/json/JsonNode;
+	public static final fun toJsonNode (Lorg/json/JSONObject;Z)Lcom/nfeld/jsonpathkt/json/JsonNode;
+}
+
+public final class com/nfeld/jsonpathkt/jsonjava/JsonJavaResolutionKt {
+	public static final fun resolveAsStringOrNull-5z6KBic (Ljava/util/List;Lorg/json/JSONArray;)Ljava/lang/String;
+	public static final fun resolveAsStringOrNull-5z6KBic (Ljava/util/List;Lorg/json/JSONObject;)Ljava/lang/String;
+	public static final fun resolveAsStringOrNull-X5kFpA0 (Lorg/json/JSONArray;Ljava/util/List;)Ljava/lang/String;
+	public static final fun resolveAsStringOrNull-X5kFpA0 (Lorg/json/JSONObject;Ljava/util/List;)Ljava/lang/String;
+	public static final fun resolveOrNull-0UCAOBU (Ljava/util/List;Lorg/json/JSONArray;Lcom/nfeld/jsonpathkt/ResolutionOptions;)Ljava/lang/Object;
+	public static final fun resolveOrNull-0UCAOBU (Ljava/util/List;Lorg/json/JSONObject;Lcom/nfeld/jsonpathkt/ResolutionOptions;)Ljava/lang/Object;
+	public static synthetic fun resolveOrNull-0UCAOBU$default (Ljava/util/List;Lorg/json/JSONArray;Lcom/nfeld/jsonpathkt/ResolutionOptions;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun resolveOrNull-0UCAOBU$default (Ljava/util/List;Lorg/json/JSONObject;Lcom/nfeld/jsonpathkt/ResolutionOptions;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun resolveOrNull-BoBP_3U (Lorg/json/JSONArray;Ljava/util/List;Lcom/nfeld/jsonpathkt/ResolutionOptions;)Ljava/lang/Object;
+	public static final fun resolveOrNull-BoBP_3U (Lorg/json/JSONObject;Ljava/util/List;Lcom/nfeld/jsonpathkt/ResolutionOptions;)Ljava/lang/Object;
+	public static synthetic fun resolveOrNull-BoBP_3U$default (Lorg/json/JSONArray;Ljava/util/List;Lcom/nfeld/jsonpathkt/ResolutionOptions;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun resolveOrNull-BoBP_3U$default (Lorg/json/JSONObject;Ljava/util/List;Lcom/nfeld/jsonpathkt/ResolutionOptions;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun resolvePathAsStringOrNull (Lorg/json/JSONArray;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun resolvePathAsStringOrNull (Lorg/json/JSONObject;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun resolvePathOrNull (Lorg/json/JSONArray;Ljava/lang/String;Lcom/nfeld/jsonpathkt/ResolutionOptions;)Ljava/lang/Object;
+	public static final fun resolvePathOrNull (Lorg/json/JSONObject;Ljava/lang/String;Lcom/nfeld/jsonpathkt/ResolutionOptions;)Ljava/lang/Object;
+	public static synthetic fun resolvePathOrNull$default (Lorg/json/JSONArray;Ljava/lang/String;Lcom/nfeld/jsonpathkt/ResolutionOptions;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun resolvePathOrNull$default (Lorg/json/JSONObject;Ljava/lang/String;Lcom/nfeld/jsonpathkt/ResolutionOptions;ILjava/lang/Object;)Ljava/lang/Object;
+}
+

--- a/jsonpath-jsonjava/build.gradle.kts
+++ b/jsonpath-jsonjava/build.gradle.kts
@@ -1,8 +1,17 @@
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
   kotlin("jvm")
   id("com.eygraber.conventions-kotlin-library")
   id("com.eygraber.conventions-detekt2")
   id("com.eygraber.conventions-publish-maven-central")
+}
+
+kotlin {
+  @OptIn(ExperimentalAbiValidation::class)
+  abiValidation {
+    enabled.set(true)
+  }
 }
 
 dependencies {

--- a/jsonpath-kotlinx/api/jsonpath-kotlinx.api
+++ b/jsonpath-kotlinx/api/jsonpath-kotlinx.api
@@ -1,0 +1,16 @@
+public final class com/nfeld/jsonpathkt/kotlinx/KotlinxJsonNodeKt {
+	public static final fun toJsonNode (Lkotlinx/serialization/json/JsonElement;Z)Lcom/nfeld/jsonpathkt/json/JsonNode;
+}
+
+public final class com/nfeld/jsonpathkt/kotlinx/KotlinxResolutionKt {
+	public static final fun resolveAsStringOrNull-5z6KBic (Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)Ljava/lang/String;
+	public static final fun resolveAsStringOrNull-X5kFpA0 (Lkotlinx/serialization/json/JsonElement;Ljava/util/List;)Ljava/lang/String;
+	public static final fun resolveOrNull-0UCAOBU (Ljava/util/List;Lkotlinx/serialization/json/JsonElement;Lcom/nfeld/jsonpathkt/ResolutionOptions;)Lkotlinx/serialization/json/JsonElement;
+	public static synthetic fun resolveOrNull-0UCAOBU$default (Ljava/util/List;Lkotlinx/serialization/json/JsonElement;Lcom/nfeld/jsonpathkt/ResolutionOptions;ILjava/lang/Object;)Lkotlinx/serialization/json/JsonElement;
+	public static final fun resolveOrNull-BoBP_3U (Lkotlinx/serialization/json/JsonElement;Ljava/util/List;Lcom/nfeld/jsonpathkt/ResolutionOptions;)Lkotlinx/serialization/json/JsonElement;
+	public static synthetic fun resolveOrNull-BoBP_3U$default (Lkotlinx/serialization/json/JsonElement;Ljava/util/List;Lcom/nfeld/jsonpathkt/ResolutionOptions;ILjava/lang/Object;)Lkotlinx/serialization/json/JsonElement;
+	public static final fun resolvePathAsStringOrNull (Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun resolvePathOrNull (Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Lcom/nfeld/jsonpathkt/ResolutionOptions;)Lkotlinx/serialization/json/JsonElement;
+	public static synthetic fun resolvePathOrNull$default (Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Lcom/nfeld/jsonpathkt/ResolutionOptions;ILjava/lang/Object;)Lkotlinx/serialization/json/JsonElement;
+}
+

--- a/jsonpath-kotlinx/api/jsonpath-kotlinx.klib.api
+++ b/jsonpath-kotlinx/api/jsonpath-kotlinx.klib.api
@@ -1,0 +1,15 @@
+// Klib ABI Dump
+// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <com.eygraber:jsonpath-kotlinx>
+final fun (com.nfeld.jsonpathkt/JsonPath).com.nfeld.jsonpathkt.kotlinx/resolveAsStringOrNull(kotlinx.serialization.json/JsonElement): kotlin/String? // com.nfeld.jsonpathkt.kotlinx/resolveAsStringOrNull|resolveAsStringOrNull@com.nfeld.jsonpathkt.JsonPath(kotlinx.serialization.json.JsonElement){}[0]
+final fun (com.nfeld.jsonpathkt/JsonPath).com.nfeld.jsonpathkt.kotlinx/resolveOrNull(kotlinx.serialization.json/JsonElement, com.nfeld.jsonpathkt/ResolutionOptions = ...): kotlinx.serialization.json/JsonElement? // com.nfeld.jsonpathkt.kotlinx/resolveOrNull|resolveOrNull@com.nfeld.jsonpathkt.JsonPath(kotlinx.serialization.json.JsonElement;com.nfeld.jsonpathkt.ResolutionOptions){}[0]
+final fun (kotlinx.serialization.json/JsonElement).com.nfeld.jsonpathkt.kotlinx/resolveAsStringOrNull(com.nfeld.jsonpathkt/JsonPath): kotlin/String? // com.nfeld.jsonpathkt.kotlinx/resolveAsStringOrNull|resolveAsStringOrNull@kotlinx.serialization.json.JsonElement(com.nfeld.jsonpathkt.JsonPath){}[0]
+final fun (kotlinx.serialization.json/JsonElement).com.nfeld.jsonpathkt.kotlinx/resolveOrNull(com.nfeld.jsonpathkt/JsonPath, com.nfeld.jsonpathkt/ResolutionOptions = ...): kotlinx.serialization.json/JsonElement? // com.nfeld.jsonpathkt.kotlinx/resolveOrNull|resolveOrNull@kotlinx.serialization.json.JsonElement(com.nfeld.jsonpathkt.JsonPath;com.nfeld.jsonpathkt.ResolutionOptions){}[0]
+final fun (kotlinx.serialization.json/JsonElement).com.nfeld.jsonpathkt.kotlinx/resolvePathAsStringOrNull(kotlin/String): kotlin/String? // com.nfeld.jsonpathkt.kotlinx/resolvePathAsStringOrNull|resolvePathAsStringOrNull@kotlinx.serialization.json.JsonElement(kotlin.String){}[0]
+final fun (kotlinx.serialization.json/JsonElement).com.nfeld.jsonpathkt.kotlinx/resolvePathOrNull(kotlin/String, com.nfeld.jsonpathkt/ResolutionOptions = ...): kotlinx.serialization.json/JsonElement? // com.nfeld.jsonpathkt.kotlinx/resolvePathOrNull|resolvePathOrNull@kotlinx.serialization.json.JsonElement(kotlin.String;com.nfeld.jsonpathkt.ResolutionOptions){}[0]
+final fun (kotlinx.serialization.json/JsonElement).com.nfeld.jsonpathkt.kotlinx/toJsonNode(kotlin/Boolean): com.nfeld.jsonpathkt.json/JsonNode // com.nfeld.jsonpathkt.kotlinx/toJsonNode|toJsonNode@kotlinx.serialization.json.JsonElement(kotlin.Boolean){}[0]

--- a/jsonpath-kotlinx/build.gradle.kts
+++ b/jsonpath-kotlinx/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
   id("com.eygraber.conventions-kotlin-multiplatform")
   id("com.eygraber.conventions-detekt2")
@@ -8,6 +10,12 @@ kotlin {
   defaultKmpTargets(
     project = project,
   )
+
+  @OptIn(ExperimentalAbiValidation::class)
+  abiValidation {
+    enabled.set(true)
+    klib.enabled.set(true)
+  }
 
   sourceSets {
     commonMain.dependencies {


### PR DESCRIPTION
Enable the Kotlin Gradle plugin's built-in ABI validation for the three
published modules (jsonpath-core, jsonpath-kotlinx, jsonpath-jsonjava) and
wire `checkKotlinAbi` into CI.

- Enable `abiValidation` (with klib validation for the KMP modules) in each
  published module's `kotlin {}` block.
- Commit the generated reference ABI dumps under each module's `api/`
  directory. The klib dump covers all 18 targets (including Apple), since
  klib ABI metadata cross-compiles on Linux.
- Add an `abi` job to the Check workflow that runs `./gradlew checkKotlinAbi`.

When public API changes intentionally, run `./gradlew updateKotlinAbi` and
commit the updated dumps.

See https://kotlinlang.org/docs/gradle-binary-compatibility-validation.html

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>