### PR TITLE
Update kotest to v6.2.0 (drop androidNativeArm32 target)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,9 @@ gradleConventionsDefaults {
 
 gradleConventionsKmpDefaults {
   targets(
-    KmpTarget.AndroidNative,
+    // KmpTarget.AndroidNative is intentionally omitted here because it also pulls in
+    // androidNativeArm32, which kotest dropped support for in 6.2.0. The remaining
+    // androidNative targets are added per-module via the raw KMP DSL.
     KmpTarget.Ios,
     KmpTarget.Js,
     KmpTarget.Jvm,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ jackson = "2.22.0"
 
 kotlin = "2.4.0"
 
-kotest = "6.1.11"
+kotest = "6.2.0"
 
 ktlint = "1.8.0"
 

--- a/jsonpath-core/api/jsonpath-core.klib.api
+++ b/jsonpath-core/api/jsonpath-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Targets: [androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/jsonpath-core/build.gradle.kts
+++ b/jsonpath-core/build.gradle.kts
@@ -12,6 +12,11 @@ kotlin {
     project = project,
   )
 
+  // androidNativeArm32 is excluded because kotest dropped support for it in 6.2.0
+  androidNativeArm64()
+  androidNativeX64()
+  androidNativeX86()
+
   @OptIn(ExperimentalAbiValidation::class)
   abiValidation()
 

--- a/jsonpath-kotlinx/api/jsonpath-kotlinx.klib.api
+++ b/jsonpath-kotlinx/api/jsonpath-kotlinx.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Targets: [androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/jsonpath-kotlinx/build.gradle.kts
+++ b/jsonpath-kotlinx/build.gradle.kts
@@ -11,6 +11,11 @@ kotlin {
     project = project,
   )
 
+  // androidNativeArm32 is excluded because kotest dropped support for it in 6.2.0
+  androidNativeArm64()
+  androidNativeX64()
+  androidNativeX86()
+
   @OptIn(ExperimentalAbiValidation::class)
   abiValidation()
 

--- a/jsonpath-test/build.gradle.kts
+++ b/jsonpath-test/build.gradle.kts
@@ -9,6 +9,11 @@ kotlin {
   defaultKmpTargets(
     project = project,
   )
+
+  // androidNativeArm32 is excluded because kotest dropped support for it in 6.2.0
+  androidNativeArm64()
+  androidNativeX64()
+  androidNativeX86()
 }
 
 gradleConventions {


### PR DESCRIPTION
Supersedes #321.

## Problem
Bumping kotest to `6.2.0` broke the `assemble` job at `compileTestKotlinAndroidNativeArm32`:

> Could not resolve `io.kotest:kotest-assertions-core:6.2.0` … No matching variant … `org.jetbrains.kotlin.native.target` with value `android_arm32`

kotest 6.2.0 **intentionally dropped the `androidNativeArm32` target** — its build now declares only `androidNativeX86/X64/Arm64`. Because JsonPathKt targeted all four `androidNative` architectures (via `KmpTarget.AndroidNative`) and its tests live in `commonTest` (which depends on kotest), the arm32 test compilation could no longer resolve the dependency.

## Fix
The conventions plugin's `KmpTarget.AndroidNative` is all-or-nothing, so to drop **only** arm32:

- Remove `KmpTarget.AndroidNative` from the shared `gradleConventionsKmpDefaults`.
- Add the still-supported `androidNativeArm64()`, `androidNativeX64()`, `androidNativeX86()` explicitly per-module (`jsonpath-core`, `jsonpath-kotlinx`, `jsonpath-test`), matching kotest's supported set.
- Bump `kotest` to `6.2.0`.
- Update the checked-in klib ABI dumps to drop `androidNativeArm32` from the `// Targets:` header.

Net effect on the published library: only `androidNativeArm32` is dropped; all other targets are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vZKMUsbWzL3SE2tT35r94

---
_Generated by [Claude Code](https://claude.ai/code/session_013vZKMUsbWzL3SE2tT35r94)_